### PR TITLE
Code clean-up and tests refactoring

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+systemProp.file.encoding=UTF-8

--- a/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/BlogPostsFetcher.java
+++ b/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/BlogPostsFetcher.java
@@ -16,7 +16,6 @@ import java.util.List;
 public class BlogPostsFetcher {
 
     private final BlogRepository blogRepository;
-    private final BlogPostRepository blogPostRepository;
     private final ActorRef rssCheckingActor;
     private final ActorRef blogPostStoringActor;
 
@@ -24,7 +23,6 @@ public class BlogPostsFetcher {
     public BlogPostsFetcher(ActorSystem actorSystem, BlogRepository blogRepository,
                             BlogPostRepository blogPostRepository, SyndFeedProducer syndFeedFactory) {
         this.blogRepository = blogRepository;
-        this.blogPostRepository = blogPostRepository;
         blogPostStoringActor = actorSystem.actorOf(NewBlogPostStoringActor.props(blogPostRepository));
         rssCheckingActor = actorSystem.actorOf(new RoundRobinPool(10)
             .props(RssCheckingActor.props(blogPostStoringActor, syndFeedFactory)), "rss-checkers");

--- a/src/main/java/pl/tomaszdziurko/jvm_bloggers/mailing/BlogSummaryMailGenerator.java
+++ b/src/main/java/pl/tomaszdziurko/jvm_bloggers/mailing/BlogSummaryMailGenerator.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.EMPTY_LIST;
+import static java.util.Collections.emptyList;
 
 @Component
 @Slf4j
@@ -63,8 +63,8 @@ public class BlogSummaryMailGenerator {
 
         Map<BlogType, List<BlogPost>> newBlogPostsByType = newApprovedPosts.stream().collect(Collectors.groupingBy(it -> it.getBlog().getBlogType()));
 
-        List<BlogPost> newPostsFromPersonalBlogs = newBlogPostsByType.getOrDefault(BlogType.PERSONAL, EMPTY_LIST);
-        List<BlogPost> newPostsfromCompanies = newBlogPostsByType.getOrDefault(BlogType.COMPANY, EMPTY_LIST);
+        List<BlogPost> newPostsFromPersonalBlogs = newBlogPostsByType.getOrDefault(BlogType.PERSONAL, emptyList());
+        List<BlogPost> newPostsfromCompanies = newBlogPostsByType.getOrDefault(BlogType.COMPANY, emptyList());
 
         Setting mailingTemplate = settingRepository.findByName(SettingKeys.MAILING_TEMPLATE.toString());
         String templateContent =  mailingTemplate.getValue();

--- a/src/main/java/pl/tomaszdziurko/jvm_bloggers/view/admin/mailing/MailingPageRequestHandler.java
+++ b/src/main/java/pl/tomaszdziurko/jvm_bloggers/view/admin/mailing/MailingPageRequestHandler.java
@@ -1,7 +1,6 @@
 package pl.tomaszdziurko.jvm_bloggers.view.admin.mailing;
 
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import pl.tomaszdziurko.jvm_bloggers.mailing.BlogSummaryMailGenerator;
@@ -13,7 +12,6 @@ import pl.tomaszdziurko.jvm_bloggers.utils.DateTimeUtilities;
 import pl.tomaszdziurko.jvm_bloggers.utils.NowProvider;
 
 @Component
-@Slf4j
 public class MailingPageRequestHandler {
 
     private MailSender mailSender;

--- a/src/main/java/pl/tomaszdziurko/jvm_bloggers/view/admin/mailing/MailingTemplateModel.java
+++ b/src/main/java/pl/tomaszdziurko/jvm_bloggers/view/admin/mailing/MailingTemplateModel.java
@@ -1,12 +1,10 @@
 package pl.tomaszdziurko.jvm_bloggers.view.admin.mailing;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.wicket.model.LoadableDetachableModel;
 import pl.tomaszdziurko.jvm_bloggers.settings.Setting;
 import pl.tomaszdziurko.jvm_bloggers.settings.SettingKeys;
 import pl.tomaszdziurko.jvm_bloggers.settings.SettingRepository;
 
-@Slf4j
 class MailingTemplateModel extends LoadableDetachableModel<Setting> {
 
     private SettingRepository settingRepository;

--- a/src/main/java/pl/tomaszdziurko/jvm_bloggers/view/admin/moderation/ModerationPage.java
+++ b/src/main/java/pl/tomaszdziurko/jvm_bloggers/view/admin/moderation/ModerationPage.java
@@ -1,6 +1,5 @@
 package pl.tomaszdziurko.jvm_bloggers.view.admin.moderation;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.authroles.authorization.strategies.role.Roles;
@@ -19,8 +18,6 @@ import pl.tomaszdziurko.jvm_bloggers.view.panels.CustomPagingNavigator;
 
 import java.time.format.DateTimeFormatter;
 
-
-@Slf4j
 @AuthorizeInstantiation(Roles.ADMIN)
 public class ModerationPage extends AbstractAdminPage {
 

--- a/src/main/java/pl/tomaszdziurko/jvm_bloggers/view/login/LoginPage.java
+++ b/src/main/java/pl/tomaszdziurko/jvm_bloggers/view/login/LoginPage.java
@@ -1,6 +1,5 @@
 package pl.tomaszdziurko.jvm_bloggers.view.login;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.wicket.RestartResponseAtInterceptPageException;
 import org.apache.wicket.authroles.authorization.strategies.role.Roles;
 import org.apache.wicket.devutils.stateless.StatelessComponent;
@@ -19,7 +18,6 @@ import pl.tomaszdziurko.jvm_bloggers.view.session.UserSession;
 import javax.servlet.http.HttpServletRequest;
 
 @StatelessComponent
-@Slf4j
 public class LoginPage extends WebPage {
 
     public static final String LOGIN_FORM_ID = "loginForm";
@@ -67,7 +65,7 @@ public class LoginPage extends WebPage {
 
         CustomFeedbackPanel feedbackPanel = new CustomFeedbackPanel("feedbackPanel");
         loginForm.add(feedbackPanel);
-        RequiredTextField loginField = new RequiredTextField(LOGIN_FIELD_ID);
+        RequiredTextField<String> loginField = new RequiredTextField<>(LOGIN_FIELD_ID);
         loginForm.add(loginField);
         PasswordTextField passwordField = new PasswordTextField(PASSWORD_FIELD_ID);
         loginForm.add(passwordField);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,7 +3,9 @@ info:
     name: JVM Bloggers
     description: Application to spread info about polish blogging JVM Developers
 
-spring.jpa.hibernate.ddl-auto: validate
+spring:
+  mandatory-file-encoding: UTF-8 
+  jpa.hibernate.ddl-auto: validate
 liquibase.change-log: classpath:db/changelog/db.changelog.xml
 
 bloggers.data.file.url: https://raw.githubusercontent.com/tdziurko/jvm-bloggers/master/bloggers.json

--- a/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/SpringContextAwareSpecification.groovy
+++ b/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/SpringContextAwareSpecification.groovy
@@ -1,0 +1,19 @@
+package pl.tomaszdziurko.jvm_bloggers
+
+import org.springframework.boot.test.SpringApplicationContextLoader
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+
+import spock.lang.Specification;
+
+@ContextConfiguration(classes = [JvmBloggersApplication], loader = SpringApplicationContextLoader)
+@ActiveProfiles("test")
+public abstract class SpringContextAwareSpecification extends Specification {
+
+    static String PASSWORD = "secretPassword";
+    
+    def setupSpec() {
+        System.setProperty("jasypt.encryptor.password", PASSWORD);
+    }
+
+}

--- a/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/jasypt/JasyptShouldEncryptPropertiesSpec.groovy
+++ b/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/jasypt/JasyptShouldEncryptPropertiesSpec.groovy
@@ -3,8 +3,10 @@ package pl.tomaszdziurko.jvm_bloggers.jasypt
 import org.jasypt.encryption.StringEncryptor
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.SpringApplicationContextLoader
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration
 import pl.tomaszdziurko.jvm_bloggers.JvmBloggersApplication
+import pl.tomaszdziurko.jvm_bloggers.SpringContextAwareSpecification;
 import spock.lang.Specification
 
 /**
@@ -14,11 +16,11 @@ import spock.lang.Specification
  *
  */
 
-@ContextConfiguration(classes = [JvmBloggersApplication], loader = SpringApplicationContextLoader)
-class JasyptShouldEncryptPropertiesSpec extends Specification {
+class JasyptShouldEncryptPropertiesSpec extends SpringContextAwareSpecification {
 
     static String PASSWORD = "secretPassword";
 
+    @Override
     def setupSpec() {
         System.setProperty("jasypt.encryptor.password", PASSWORD);
     }

--- a/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/mailing/IssueNumberRetrieverSpec.groovy
+++ b/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/mailing/IssueNumberRetrieverSpec.groovy
@@ -4,17 +4,14 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.SpringApplicationContextLoader
 import org.springframework.test.context.ContextConfiguration
 import pl.tomaszdziurko.jvm_bloggers.JvmBloggersApplication
+import pl.tomaszdziurko.jvm_bloggers.SpringContextAwareSpecification;
 import spock.lang.Specification
 
-@ContextConfiguration(classes = [JvmBloggersApplication], loader = SpringApplicationContextLoader)
-class IssueNumberRetrieverSpec extends Specification {
+
+class IssueNumberRetrieverSpec extends SpringContextAwareSpecification {
 
     @Autowired
     IssueNumberRetriever issueNumberRetriever
-
-    def setupSpec() {
-        System.setProperty("jasypt.encryptor.password", "password")
-    }
 
     def "Should get next issue numbers starting from 8"() {
         when:

--- a/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/mailing/domain/MailingAddressRepositorySpec.groovy
+++ b/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/mailing/domain/MailingAddressRepositorySpec.groovy
@@ -4,17 +4,14 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.SpringApplicationContextLoader
 import org.springframework.test.context.ContextConfiguration
 import pl.tomaszdziurko.jvm_bloggers.JvmBloggersApplication
+import pl.tomaszdziurko.jvm_bloggers.SpringContextAwareSpecification;
 import spock.lang.Specification
 
-@ContextConfiguration(classes = [JvmBloggersApplication], loader = SpringApplicationContextLoader)
-class MailingAddressRepositorySpec extends Specification {
+
+class MailingAddressRepositorySpec extends SpringContextAwareSpecification {
 
     @Autowired
     MailingAddressRepository mailingAddressRepository
-
-    def setupSpec() {
-        System.setProperty("jasypt.encryptor.password", "password")
-    }
 
     def "Should persist MailingAddress"() {
         given:

--- a/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/view/login/LoginPageSpec.groovy
+++ b/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/view/login/LoginPageSpec.groovy
@@ -8,22 +8,17 @@ import org.springframework.boot.test.SpringApplicationContextLoader
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.util.ReflectionTestUtils
 import pl.tomaszdziurko.jvm_bloggers.JvmBloggersApplication
+import pl.tomaszdziurko.jvm_bloggers.SpringContextAwareSpecification;
 import pl.tomaszdziurko.jvm_bloggers.view.admin.AdminDashboardPage
 import spock.lang.Specification
 
-@ContextConfiguration(classes = [JvmBloggersApplication], loader = SpringApplicationContextLoader)
-class LoginPageSpec extends Specification {
 
-    static String PASSWORD = "superSecretPassword"
+class LoginPageSpec extends SpringContextAwareSpecification {
 
     private WicketTester tester
 
     @Autowired
     private WebApplication wicketApplication
-
-    def setupSpec() {
-        System.setProperty("jasypt.encryptor.password", PASSWORD);
-    }
 
     def setup() {
         // This is a workaround for problems with Spring Boot and WicketTester

--- a/src/test/java/pl/tomaszdziurko/jvm_bloggers/JvmBloggersApplicationTests.java
+++ b/src/test/java/pl/tomaszdziurko/jvm_bloggers/JvmBloggersApplicationTests.java
@@ -4,12 +4,14 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = JvmBloggersApplication.class)
 @WebAppConfiguration
+@ActiveProfiles("test")
 public class JvmBloggersApplicationTests {
 
     @BeforeClass

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -3,6 +3,7 @@ liquibase.change-log: classpath:db/changelog/db.changelog.xml
 bloggers.data.file.url: https://raw.githubusercontent.com/tdziurko/jvm-bloggers/master/bloggers.json
 companies.data.file.url: https://raw.githubusercontent.com/tdziurko/jvm-bloggers/master/companies.json
 
+spring.jpa.hibernate.ddl-auto: none
 # Mail Configuration
 mailing:
   apiKey: "apiKey"


### PR DESCRIPTION
1. By code clean-up I meant:
 - removing unused variables
 - adding missing type parameters to variable declarations
 - other warnings compiler complained about

2. Test cases that relies on Spring container were refactored to remove repetitiveness (mainly duplicated `setupSpec` methods and `@ContextConfiguration` annotations in each test) by pulling common parts to new [`SpringContextAwareSpecification`](https://github.com/goostleek/jvm-bloggers/blob/code-cleanup/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/SpringContextAwareSpecification.groovy) class. Additionally tests related _application.yaml_ file was renamed to _application-test.yaml_ to resolve strange Eclipse related warnings about duplicated resources that led to failed unit tests when using IDE to launch tests.

3. I have also provided a fix for home page encoding issues when launching app from gradle on systems that uses non-standard locale (like Polish). In other words application will look the same regardless platform encoding (UTF-8 is enforced).