### PR TITLE
Issue/#106/blog-post-description

### DIFF
--- a/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/NewBlogPostStoringActor.java
+++ b/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/NewBlogPostStoringActor.java
@@ -9,7 +9,6 @@ import akka.japi.pf.ReceiveBuilder;
 import com.sun.syndication.feed.synd.SyndContent;
 import com.sun.syndication.feed.synd.SyndEntry;
 
-import lombok.experimental.ExtensionMethod;
 import lombok.extern.slf4j.Slf4j;
 import pl.tomaszdziurko.jvm_bloggers.blog_posts.domain.BlogPost;
 import pl.tomaszdziurko.jvm_bloggers.blog_posts.domain.BlogPostRepository;
@@ -20,7 +19,6 @@ import java.util.Date;
 import org.apache.commons.lang3.StringUtils;
 
 @Slf4j
-@ExtensionMethod({DateTimeUtilities.class, StringUtils.class})
 public class NewBlogPostStoringActor extends AbstractActor {
 
     public NewBlogPostStoringActor(BlogPostRepository blogPostRepository) {
@@ -41,7 +39,7 @@ public class NewBlogPostStoringActor extends AbstractActor {
         return BlogPost.builder()
                 .title(postInRss.getTitle())
                 .url(postInRss.getLink())
-                .publishedDate(dateToStore.convertDateToLocalDateTime())
+                .publishedDate(DateTimeUtilities.convertDateToLocalDateTime(dateToStore))
                 .approved(rssEntry.getBlog().getDefaultApprovedValue())
                 .blog(rssEntry.getBlog())
                 .build();
@@ -49,7 +47,8 @@ public class NewBlogPostStoringActor extends AbstractActor {
 
     private void updateDescription(BlogPost blogPost, SyndContent descriptionContent) {
         if (descriptionContent != null) {
-            final String description = descriptionContent.getValue().abbreviate(BlogPost.MAX_DESCRIPTION_LENGTH);
+            String description = descriptionContent.getValue();
+            description = StringUtils.abbreviate(description, BlogPost.MAX_DESCRIPTION_LENGTH);
             blogPost.setDescription(description);
         }
     }

--- a/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/RssEntryWithAuthor.java
+++ b/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/RssEntryWithAuthor.java
@@ -1,21 +1,17 @@
 package pl.tomaszdziurko.jvm_bloggers.blog_posts;
 
-import com.google.common.base.Preconditions;
 import com.sun.syndication.feed.synd.SyndEntry;
-import lombok.Getter;
+
+import lombok.Data;
+import lombok.NonNull;
 import pl.tomaszdziurko.jvm_bloggers.blogs.domain.Blog;
 
-@Getter
+@Data
 public class RssEntryWithAuthor {
 
+    @NonNull
     private final Blog blog;
+    @NonNull
     private final SyndEntry rssEntry;
-
-    public RssEntryWithAuthor(Blog blog, SyndEntry rssEntry) {
-        Preconditions.checkArgument(blog != null, "Blog can not be null");
-        Preconditions.checkArgument(rssEntry != null, "Rss entry can not be null");
-        this.blog = blog;
-        this.rssEntry = rssEntry;
-    }
 
 }

--- a/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/domain/BlogPost.java
+++ b/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/domain/BlogPost.java
@@ -29,6 +29,8 @@ import java.util.UUID;
 @Builder
 public class BlogPost {
 
+    public static final int MAX_DESCRIPTION_LENGTH = 4096;
+
     @Id
     @GeneratedValue(generator = "BLOG_POST_SEQ", strategy = GenerationType.SEQUENCE)
     @SequenceGenerator(name = "BLOG_POST_SEQ", sequenceName = "BLOG_POST_SEQ", allocationSize = 1)
@@ -40,6 +42,9 @@ public class BlogPost {
 
     @Column(name = "TITLE", nullable = false, length = 250)
     private String title;
+
+    @Column(name = "DESCRIPTION", length = MAX_DESCRIPTION_LENGTH)
+    private String description;
 
     @Column(name = "URL", unique = true, nullable = false, length = 500)
     private String url;

--- a/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/domain/BlogPost.java
+++ b/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/domain/BlogPost.java
@@ -1,6 +1,9 @@
 package pl.tomaszdziurko.jvm_bloggers.blog_posts.domain;
 
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import pl.tomaszdziurko.jvm_bloggers.blogs.domain.Blog;
@@ -14,13 +17,16 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
 @Table(name = "blog_post")
 @Data
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class BlogPost {
 
     @Id
@@ -30,7 +36,7 @@ public class BlogPost {
     private Long id;
 
     @Column(name = "UID", unique = true, nullable = false)
-    private String uid;
+    private final String uid = UUID.randomUUID().toString();
 
     @Column(name = "TITLE", nullable = false, length = 250)
     private String title;
@@ -47,19 +53,6 @@ public class BlogPost {
     @ManyToOne
     @JoinColumn(name = "BLOG_ID", nullable = false)
     private Blog blog;
-
-    public BlogPost(String title, Blog blog, String url, LocalDateTime publishedDate) {
-        this(title, blog, url, publishedDate, true);
-    }
-
-    public BlogPost(String title, Blog blog, String url, LocalDateTime publishedDate, Boolean approved) {
-        this.uid = UUID.randomUUID().toString();
-        this.title = title;
-        this.blog = blog;
-        this.url = url;
-        this.publishedDate = publishedDate;
-        this.approved = approved;
-    }
 
     public boolean isApproved() {
         return Boolean.TRUE.equals(approved);

--- a/src/main/resources/db/changelog/db.changelog.xml
+++ b/src/main/resources/db/changelog/db.changelog.xml
@@ -169,4 +169,10 @@
         <dropNotNullConstraint tableName="BLOG_POST" columnName="APPROVED" columnDataType="boolean"/>
     </changeSet>
 
+    <changeSet id="017-added-DESCRIPTION-column-to-BLOG_POST-table" author="Marcin Kłopotek">
+        <addColumn tableName="blog_post">
+            <column name="DESCRIPTION" type="varchar(4096)"/>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
RSS specification does not restrict _description_ length for RSS items so I assumed maximum length to be 4096 characters in db. Even then we have blog post items that descriptions exceed this limit (the longest description was longer that 10000 chcracters). To avoid `SQLException` in such cases we have to [trim the description](https://github.com/tdziurko/jvm-bloggers/pull/111/files#diff-3debb56cf34039d629e8552c6a684e50R52) to fit `description` column of the `BlogPost` entity.