### PR TITLE
Issue 112 introduce common formatting, closes #112

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ dependencies {
 }
 
 checkstyle {
-    toolVersion = "6.5"
+    toolVersion = "6.16.1"
 }
 
 jacoco {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -18,7 +18,7 @@
 <module name = "Checker">
     <property name="charset" value="UTF-8"/>
 
-    <property name="severity" value="warning"/>
+    <property name="severity" value="error"/>
 
     <property name="fileExtensions" value="java, properties, xml"/>
     <!-- Checks for whitespace                               -->

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -159,9 +159,8 @@
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
         <module name="CustomImportOrder">
-            <property name="specialImportsRegExp" value="com.google"/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
+            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
         </module>
         <module name="MethodParamPad"/>
         <module name="OperatorWrap">

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,159 +1,210 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 
-<module name="Checker">
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html.
 
-    <module name="SuppressionCommentFilter">
-        <property name="offCommentFormat" value="CHECKSTYLE:OFF"/>
-        <property name="onCommentFormat" value="CHECKSTYLE:ON"/>
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.sf.net (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+
+    Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name = "Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <property name="severity" value="warning"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
     </module>
-
-    <module name="RegexpSingleline">
-        <property name="format" value="serialVersionUID"/>
-        <property name="message" value="No serialVersionUID declaration allowed"/>
-    </module>
-
-    <module name="RegexpSingleline">
-        <property name="format" value="printStacktrace()"/>
-        <property name="message" value="Stacktrace printing is not allowed"/>
-    </module>
-
-    <module name="RegexpSingleline">
-        <property name="format" value="System.out.println()"/>
-        <property name="message" value="System.out.println() is not allowed"/>
-    </module>
-
-    <module name="RegexpSingleline">
-        <property name="format" value="org.drools.core.util.StringUtils"/>
-        <property name="message" value="StringUtils from Drools is used."/>
-    </module>
-
-    <module name="FileLength">
-        <property name="max" value="2000"/>
-    </module>
-
-    <module name="FileTabCharacter" />
 
     <module name="TreeWalker">
-        <module name="FileContentsHolder"/>
-        <module name="EmptyBlock"/>
-        <module name="LeftCurly" />
-        <module name="RightCurly" />
-        <module name="NeedBraces" />
-        <module name="AvoidNestedBlocks" />
-
-        <!-- Coding -->
-        <module name="EqualsHashCode"/>
-        <module name="EmptyStatement"/>
-        <module name="InnerAssignment"/>
-        <module name="StringLiteralEquality"/>
-        <module name="MissingSwitchDefault"/>
-        <module name="MultipleVariableDeclarations"/>
-        <module name="DefaultComesLast"/>
-        <module name="NoClone"/>
-        <module name="NoFinalizer"/>
-        <module name="OneStatementPerLine"/>
-        <module name="DeclarationOrder"/>
-        <module name="SimplifyBooleanExpression"/>
-        <module name="SimplifyBooleanReturn"/>
-        <module name="IllegalThrows"/>
-        <module name="ModifiedControlVariable"/>
-        <module name="UnnecessaryParentheses" />
-        <module name="HiddenField">
-            <property name="tokens" value="VARIABLE_DEF"/>
+        <module name="OuterTypeFilename"/>
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+            <property name="format" value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message" value="Avoid using corresponding octal or Unicode escape."/>
         </module>
-        <module name="NestedTryDepth">
-             <property name="max" value="1"/>
-        </module>
-        <module name="NestedIfDepth">
-             <property name="max" value="2"/>
-        </module>
-        <module name="NestedForDepth">
-             <property name="max" value="2"/>
-        </module>
-
-        <!-- Class design -->
-        <module name="ThrowsCount">
-            <property name="max" value="2"/>
-        </module>
-        <module name="InnerTypeLast"/>
-        <module name="VisibilityModifier">
-            <property name="packageAllowed" value="true" />
-        </module>
-
-        <!-- Annotations -->
-        <module name="MissingOverride"/>
-        <module name="SuppressWarnings">
-            <property name="format" value="^serial$|^unused$"/>
-        </module>
-
-        <!-- Imports -->
-        <module name="RedundantImport" />
-        <module name="UnusedImports" />
-
-        <module name="AvoidStarImport">
-            <property name="allowStaticMemberImports" value="true"/>
-        </module>
-
-        <module name="TodoComment">
-            <property name="format" value="TODO|FIXME"/>
-        </module>
-
-        <!-- Metrics -->
-
-        <!-- Misc -->
-        <module name="UpperEll" />
-        <module name="ArrayTypeStyle" />
-        <module name="OuterTypeFilename" />
-        <module name="Indentation" />
-
-        <!-- Modifiers -->
-        <module name="ModifierOrder" />
-        <module name="RedundantModifier" />
-
-        <!-- Naming -->
-        <module name="AbstractClassName"/>
-        <module name="ClassTypeParameterName"/>
-        <module name="ConstantName"/>
-        <module name="LocalFinalVariableName"/>
-        <module name="LocalVariableName"/>
-        <module name="MemberName"/>
-        <module name="MethodName"/>
-        <module name="MethodTypeParameterName"/>
-        <module name="PackageName"/>
-        <module name="ParameterName"/>
-        <module name="StaticVariableName"/>
-        <module name="TypeName"/>
-
-        <!-- Sizes -->
-        <module name="OuterTypeNumber">
-            <property name="max" value="1"/>
-        </module>
-        <module name="MethodLength">
-            <property name="max" value="100"/>
-        </module>
-        <module name="AnonInnerLength">
-            <property name="max" value="50"/>
+        <module name="AvoidEscapedUnicodeCharacters">
+            <property name="allowEscapesForControlCharacters" value="true"/>
+            <property name="allowByTailComment" value="true"/>
+            <property name="allowNonPrintableEscapes" value="true"/>
         </module>
         <module name="LineLength">
-            <property name="max" value="150"/>
+            <property name="max" value="100"/>
+            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
         </module>
-
-        <!-- Whitespaces -->
-        <module name="MethodParamPad" />
-        <module name="WhitespaceAround" />
-        <module name="WhitespaceAfter" />
-        <module name="NoWhitespaceAfter">
-            <property name="tokens" value="BNOT, DEC, DOT, INC, LNOT, UNARY_MINUS, UNARY_PLUS"/>
+        <module name="AvoidStarImport"/>
+        <module name="OneTopLevelClass"/>
+        <module name="NoLineWrap"/>
+        <module name="EmptyBlock">
+            <property name="option" value="TEXT"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
-        <module name="NoWhitespaceBefore" />
-        <module name="OperatorWrap" />
-        <module name="ParenPad" />
-        <module name="TypecastParenPad" />
-
+        <module name="NeedBraces"/>
+        <module name="LeftCurly">
+            <property name="maxLineLength" value="100"/>
+        </module>
+        <module name="RightCurly"/>
+        <module name="RightCurly">
+            <property name="option" value="alone"/>
+            <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT"/>
+        </module>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyTypes" value="true"/>
+            <property name="allowEmptyLoops" value="true"/>
+            <message key="ws.notFollowed"
+                     value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+            <message key="ws.notPreceded"
+                     value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="OneStatementPerLine"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="ArrayTypeStyle"/>
         <module name="MissingSwitchDefault"/>
         <module name="FallThrough"/>
+        <module name="UpperEll"/>
+        <module name="ModifierOrder"/>
+        <module name="EmptyLineSeparator">
+            <property name="allowNoEmptyLineBetweenFields" value="true"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="DOT"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+            <message key="name.invalidPattern"
+                     value="Package name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="TypeName">
+            <message key="name.invalidPattern"
+                     value="Type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MemberName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+                     value="Member name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ParameterName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+                     value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="CatchParameterName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+                     value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LocalVariableName">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+            <property name="allowOneCharVarInForLoop" value="true"/>
+            <message key="name.invalidPattern"
+                     value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+                     value="Class type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+                     value="Method type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="InterfaceTypeParameterName">
+            <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+            <message key="name.invalidPattern"
+                     value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="NoFinalizer"/>
+        <module name="GenericWhitespace">
+            <message key="ws.followed"
+                     value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+            <message key="ws.preceded"
+                     value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+            <message key="ws.illegalFollow"
+                     value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+            <message key="ws.notPreceded"
+                     value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="Indentation">
+            <property name="basicOffset" value="2"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="2"/>
+            <property name="throwsIndent" value="4"/>
+            <property name="lineWrappingIndentation" value="4"/>
+            <property name="arrayInitIndent" value="2"/>
+        </module>
+        <module name="AbbreviationAsWordInName">
+            <property name="ignoreFinal" value="false"/>
+            <property name="allowedAbbreviationLength" value="1"/>
+        </module>
+        <module name="OverloadMethodsDeclarationOrder"/>
+        <module name="VariableDeclarationUsageDistance"/>
+        <module name="CustomImportOrder">
+            <property name="specialImportsRegExp" value="com.google"/>
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
+            <property name="customImportOrderRules" value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
+        </module>
+        <module name="MethodParamPad"/>
+        <module name="OperatorWrap">
+            <property name="option" value="NL"/>
+            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="allowSamelineMultipleAnnotations" value="true"/>
+        </module>
+        <module name="NonEmptyAtclauseDescription"/>
+        <module name="JavadocTagContinuationIndentation"/>
+        <module name="SummaryJavadoc">
+            <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+        </module>
+        <module name="JavadocParagraph"/>
+        <module name="AtclauseOrder">
+            <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+            <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+        </module>
+        <module name="JavadocMethod">
+            <property name="scope" value="public"/>
+            <property name="allowMissingParamTags" value="true"/>
+            <property name="allowMissingThrowsTags" value="true"/>
+            <property name="allowMissingReturnTag" value="true"/>
+            <property name="minLineCount" value="2"/>
+            <property name="allowedAnnotations" value="Override, Test"/>
+            <property name="allowThrowsTagsForSubclasses" value="true"/>
+        </module>
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+            <message key="name.invalidPattern"
+                     value="Method name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="SingleLineJavadoc">
+            <property name="ignoreInlineTags" value="false"/>
+        </module>
+        <module name="EmptyCatchBlock">
+            <property name="exceptionVariableName" value="expected"/>
+        </module>
+        <module name="CommentsIndentation"/>
     </module>
 </module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -196,5 +196,6 @@
             <property name="exceptionVariableName" value="expected"/>
         </module>
         <module name="CommentsIndentation"/>
+        <module name="NewlineAtEndOfFile"/>
     </module>
 </module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -88,7 +88,7 @@
             <property name="option" value="EOL"/>
         </module>
         <module name="PackageName">
-            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+            <property name="format" value="^[a-z]+(\.[a-z][a-z_0-9]*)*$"/>
             <message key="name.invalidPattern"
                      value="Package name ''{0}'' must match pattern ''{1}''."/>
         </module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -27,6 +27,10 @@
         <property name="eachLine" value="true"/>
     </module>
 
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf"/>
+    </module>
+
     <module name="TreeWalker">
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
@@ -196,6 +200,5 @@
             <property name="exceptionVariableName" value="expected"/>
         </module>
         <module name="CommentsIndentation"/>
-        <module name="NewlineAtEndOfFile"/>
     </module>
 </module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -109,7 +109,7 @@
         <module name="CatchParameterName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
             <message key="name.invalidPattern"
-                     value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+                     value="Catch parameter name ''{0}'' must match pattern ''{1}''. I can''t be a simple ''e''"/>
         </module>
         <module name="LocalVariableName">
             <property name="tokens" value="VARIABLE_DEF"/>
@@ -160,7 +160,7 @@
         <module name="VariableDeclarationUsageDistance"/>
         <module name="CustomImportOrder">
             <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
+            <property name="customImportOrderRules" value="THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE###STATIC"/>
         </module>
         <module name="MethodParamPad"/>
         <module name="OperatorWrap">

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -184,15 +184,6 @@
             <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
             <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
-        <module name="JavadocMethod">
-            <property name="scope" value="public"/>
-            <property name="allowMissingParamTags" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
-            <property name="allowMissingReturnTag" value="true"/>
-            <property name="minLineCount" value="2"/>
-            <property name="allowedAnnotations" value="Override, Test"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
-        </module>
         <module name="MethodName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
             <message key="name.invalidPattern"

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -145,12 +145,12 @@
                      value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
         </module>
         <module name="Indentation">
-            <property name="basicOffset" value="2"/>
+            <property name="basicOffset" value="4"/>
             <property name="braceAdjustment" value="0"/>
-            <property name="caseIndent" value="2"/>
+            <property name="caseIndent" value="4"/>
             <property name="throwsIndent" value="4"/>
             <property name="lineWrappingIndentation" value="4"/>
-            <property name="arrayInitIndent" value="2"/>
+            <property name="arrayInitIndent" value="4"/>
         </module>
         <module name="AbbreviationAsWordInName">
             <property name="ignoreFinal" value="false"/>

--- a/config/formatters/How-to.md
+++ b/config/formatters/How-to.md
@@ -1,11 +1,16 @@
+# Installation tips
 
 
-# Formatter for IntelliJ IDEA
+## Formatter for IntelliJ IDEA
 
-1. Copy intellij-java-google-syule.xml into your config/codestyles folder in your IntelliJ settings folder. 
+1. Copy intellij-java-google-style.xml into your config/codestyles folder in your IntelliJ settings folder. 
 
 2. Under Settings/Code Style select the "GoogleStyle" as current code style for the project.
 
-# Formatter for Eclipse
+## Formatter for Eclipse
 
 1. Under Window/Preferences select Java/Code Style/Formatter. Import the settings file by selecting Import.
+
+## Formatter for NetBeans
+
+Unfortunately there is no formatter for NetBeans with Google Java Style. You can try to use [Eclipse Java Code Formatter Integration for NetBeans](http://plugins.netbeans.org/plugin/50877/eclipse-code-formatter-for-java).

--- a/config/formatters/How-to.md
+++ b/config/formatters/How-to.md
@@ -1,0 +1,11 @@
+
+
+# Formatter for IntelliJ IDEA
+
+1. Copy intellij-java-google-syule.xml into your config/codestyles folder in your IntelliJ settings folder. 
+
+2. Under Settings/Code Style select the "GoogleStyle" as current code style for the project.
+
+# Formatter for Eclipse
+
+1. Under Window/Preferences select Java/Code Style/Formatter. Import the settings file by selecting Import.

--- a/config/formatters/How-to.md
+++ b/config/formatters/How-to.md
@@ -7,12 +7,11 @@
 
 2. Under Settings/Code Style select the "GoogleStyle" as current code style for the project.
 
-**Tip** You can create a symbolic link from formatter file in jvm-bloggers project directory to the confif/codestyles directory. Still you need to restart IDEA to see the changes.
+**Tip** You can create a symbolic link from formatter file in jvm-bloggers project directory to the config/codestyles directory. Still you need to restart IDEA to see the changes.
 
 ## Formatter for Eclipse
 
 1. Under Window/Preferences select Java/Code Style/Formatter. Import the settings file by selecting Import.
 
-## Formatter for NetBeans
-
+## Formatter for NetBean
 Unfortunately there is no formatter for NetBeans with Google Java Style. You can try to use [Eclipse Java Code Formatter Integration for NetBeans](http://plugins.netbeans.org/plugin/50877/eclipse-code-formatter-for-java).

--- a/config/formatters/How-to.md
+++ b/config/formatters/How-to.md
@@ -7,6 +7,8 @@
 
 2. Under Settings/Code Style select the "GoogleStyle" as current code style for the project.
 
+**Tip** You can create a symbolic link from formatter file in jvm-bloggers project directory to the confif/codestyles directory. Still you need to restart IDEA to see the changes.
+
 ## Formatter for Eclipse
 
 1. Under Window/Preferences select Java/Code Style/Formatter. Import the settings file by selecting Import.

--- a/config/formatters/eclipse-java-google-style.xml
+++ b/config/formatters/eclipse-java-google-style.xml
@@ -1,10 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
 <!--
 
 File downloaded from https://github.com/google/styleguide/blob/gh-pages/eclipse-java-google-style.xml
 
 -->
-
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <profiles version="13">
     <profile kind="CodeFormatterProfile" name="GoogleStyle" version="13">
         <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>

--- a/config/formatters/eclipse-java-google-style.xml
+++ b/config/formatters/eclipse-java-google-style.xml
@@ -1,0 +1,343 @@
+<!--
+
+File downloaded from https://github.com/google/styleguide/blob/gh-pages/eclipse-java-google-style.xml
+
+-->
+
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="13">
+    <profile kind="CodeFormatterProfile" name="GoogleStyle" version="13">
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_cascading_method_invocation_with_arguments.count_dependent" value="16|-1|16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_prefer_two_fragments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_comment_inline_tags" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_local_variable_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_parameter" value="1040"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type.count_dependent" value="1585|-1|1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields.count_dependent" value="16|-1|16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression.count_dependent" value="16|4|80"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration.count_dependent" value="16|4|48"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration.count_dependent" value="16|4|49"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_cascading_method_invocation_with_arguments" value="16"/>
+        <setting id="org.eclipse.jdt.core.compiler.source" value="1.7"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration.count_dependent" value="16|4|48"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_local_variable_annotation" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants.count_dependent" value="16|5|48"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.lineSplit" value="100"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation.count_dependent" value="16|4|48"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package" value="1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="16"/>
+        <setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_type_annotation" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_field_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_generic_type_arguments" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment_new_line_at_start_of_html_paragraph" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comment_prefix" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_parameter_annotation" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method" value="1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation.count_dependent" value="16|5|80"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_parameter.count_dependent" value="1040|-1|1040"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package.count_dependent" value="1585|-1|1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.force_if_else_statement_brace" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="3"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_package_annotation" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation.count_dependent" value="16|-1|16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type" value="1585"/>
+        <setting id="org.eclipse.jdt.core.compiler.compliance" value="1.7"/>
+        <setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_new_anonymous_class" value="20"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable.count_dependent" value="1585|-1|1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field.count_dependent" value="1585|-1|1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration.count_dependent" value="16|5|80"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+        <setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant.count_dependent" value="16|-1|16"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="100"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="2"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field" value="1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer.count_dependent" value="16|5|80"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.7"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+        <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration.count_dependent" value="16|4|48"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method.count_dependent" value="1585|-1|1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression.count_dependent" value="16|-1|16"/>
+        <setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_member_annotation" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable" value="1585"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call.count_dependent" value="16|5|80"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_generic_type_arguments.count_dependent" value="16|-1|16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression.count_dependent" value="16|5|80"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration.count_dependent" value="16|5|80"/>
+        <setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_for_statement" value="16"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+        <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+    </profile>
+</profiles>

--- a/config/formatters/intellij-java-google-style.xml
+++ b/config/formatters/intellij-java-google-style.xml
@@ -1,281 +1,276 @@
 <code_scheme name="GoogleStyle">
-    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
-    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
-    <option name="IMPORT_LAYOUT_TABLE">
-        <value>
-            <package name="com.google" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="android" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="antenna" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="antlr" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="ar" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="asposewobfuscated" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="asquare" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="atg" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="au" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="beaver" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="bibtex" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="bmsi" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="bsh" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="ccl" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="cern" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="ChartDirector" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="checkers" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="com" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="COM" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="common" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="contribs" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="corejava" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="cryptix" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="cybervillains" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="dalvik" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="danbikel" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="de" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="EDU" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="eg" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="eu" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="examples" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="fat" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="fit" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="fitlibrary" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="fmpp" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="freemarker" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="gnu" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="groovy" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="groovyjarjarantlr" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="groovyjarjarasm" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="hak" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="hep" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="ie" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="imageinfo" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="info" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="it" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="jal" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="Jama" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="japa" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="japacheckers" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="jas" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="jasmin" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="javancss" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="javanet" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="javassist" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="javazoom" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="java_cup" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="jcifs" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="jetty" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="JFlex" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="jj2000" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="jline" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="jp" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="JSci" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="jsr166y" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="junit" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="jxl" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="jxxload_help" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="kawa" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="kea" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="libcore" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="libsvm" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="lombok" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="lti" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="memetic" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="mt" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="mx4j" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="net" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="netscape" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="nl" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="nu" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="oauth" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="ognl" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="opennlp" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="oracle" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="org" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="penn2dg" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="pennconverter" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="pl" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="prefuse" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="proguard" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="repackage" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="scm" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="se" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="serp" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="simple" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="soot" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="sqlj" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="src" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="ssa" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="sun" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="sunlabs" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="tcl" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="testdata" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="testshell" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="testsuite" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="twitter4j" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="uk" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="ViolinStrings" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="weka" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="wet" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="winstone" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="woolfel" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="wowza" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="java" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="javax" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="" withSubpackages="true" static="false" />
-            <emptyLine />
-            <package name="" withSubpackages="true" static="true" />
-        </value>
-    </option>
-    <option name="JD_P_AT_EMPTY_LINES" value="false" />
-    <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
-    <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
-    <option name="JD_KEEP_EMPTY_RETURN" value="false" />
-    <JavaCodeStyleSettings>
-        <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true" />
-    </JavaCodeStyleSettings>
-    <XML>
-        <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
-    </XML>
-    <codeStyleSettings language="JAVA">
-        <option name="RIGHT_MARGIN" value="100" />
-        <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
-        <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-        <option name="CALL_PARAMETERS_WRAP" value="1" />
-        <option name="METHOD_PARAMETERS_WRAP" value="1" />
-        <option name="EXTENDS_LIST_WRAP" value="1" />
-        <option name="THROWS_LIST_WRAP" value="1" />
-        <option name="EXTENDS_KEYWORD_WRAP" value="1" />
-        <option name="THROWS_KEYWORD_WRAP" value="1" />
-        <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-        <option name="BINARY_OPERATION_WRAP" value="1" />
-        <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-        <option name="TERNARY_OPERATION_WRAP" value="1" />
-        <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-        <option name="FOR_STATEMENT_WRAP" value="1" />
-        <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-        <option name="ASSIGNMENT_WRAP" value="5" />
-        <option name="IF_BRACE_FORCE" value="3" />
-        <option name="DOWHILE_BRACE_FORCE" value="3" />
-        <option name="WHILE_BRACE_FORCE" value="3" />
-        <option name="FOR_BRACE_FORCE" value="3" />
-        <indentOptions>
-            <option name="INDENT_SIZE" value="2" />
-            <option name="CONTINUATION_INDENT_SIZE" value="4" />
-            <option name="TAB_SIZE" value="8" />
-        </indentOptions>
-    </codeStyleSettings>
+  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+  <option name="IMPORT_LAYOUT_TABLE">
+    <value>
+      <package name="com.google" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="android" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="antenna" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="antlr" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="ar" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="asposewobfuscated" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="asquare" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="atg" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="au" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="beaver" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="bibtex" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="bmsi" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="bsh" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="ccl" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="cern" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="ChartDirector" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="checkers" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="com" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="COM" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="common" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="contribs" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="corejava" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="cryptix" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="cybervillains" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="dalvik" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="danbikel" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="de" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="EDU" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="eg" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="eu" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="examples" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="fat" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="fit" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="fitlibrary" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="fmpp" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="freemarker" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="gnu" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="groovy" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="groovyjarjarantlr" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="groovyjarjarasm" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="hak" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="hep" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="ie" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="imageinfo" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="info" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="it" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="jal" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="Jama" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="japa" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="japacheckers" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="jas" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="jasmin" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="javancss" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="javanet" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="javassist" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="javazoom" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="java_cup" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="jcifs" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="jetty" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="JFlex" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="jj2000" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="jline" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="jp" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="JSci" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="jsr166y" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="junit" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="jxl" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="jxxload_help" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="kawa" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="kea" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="libcore" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="libsvm" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="lombok" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="lti" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="memetic" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="mt" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="mx4j" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="net" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="netscape" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="nl" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="nu" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="oauth" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="ognl" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="opennlp" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="oracle" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="org" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="penn2dg" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="pennconverter" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="pl" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="prefuse" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="proguard" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="repackage" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="scm" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="se" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="serp" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="simple" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="soot" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="sqlj" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="src" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="ssa" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="sun" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="sunlabs" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="tcl" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="testdata" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="testshell" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="testsuite" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="twitter4j" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="uk" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="ViolinStrings" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="weka" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="wet" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="winstone" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="woolfel" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="wowza" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="java" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="javax" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="" withSubpackages="true" static="false" />
+      <emptyLine />
+      <package name="" withSubpackages="true" static="true" />
+    </value>
+  </option>
+  <option name="JD_P_AT_EMPTY_LINES" value="false" />
+  <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
+  <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
+  <option name="JD_KEEP_EMPTY_RETURN" value="false" />
+  <JavaCodeStyleSettings>
+    <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true" />
+  </JavaCodeStyleSettings>
+  <XML>
+    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+  </XML>
+  <codeStyleSettings language="JAVA">
+    <option name="RIGHT_MARGIN" value="100" />
+    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="EXTENDS_LIST_WRAP" value="1" />
+    <option name="THROWS_LIST_WRAP" value="1" />
+    <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+    <option name="THROWS_KEYWORD_WRAP" value="1" />
+    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+    <option name="TERNARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+    <option name="ASSIGNMENT_WRAP" value="5" />
+    <option name="IF_BRACE_FORCE" value="3" />
+    <option name="DOWHILE_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="3" />
+    <option name="FOR_BRACE_FORCE" value="3" />
+  </codeStyleSettings>
 </code_scheme>

--- a/config/formatters/intellij-java-google-style.xml
+++ b/config/formatters/intellij-java-google-style.xml
@@ -1,10 +1,3 @@
-<!--
-
-File downloaded from https://github.com/google/styleguide/pull/75/files (original formatter for IDEA with some
-additional fixes for IDEA 14/15.
-
--->
-
 <code_scheme name="GoogleStyle">
     <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
     <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
@@ -153,6 +146,8 @@ additional fixes for IDEA 14/15.
             <package name="libcore" withSubpackages="true" static="false" />
             <emptyLine />
             <package name="libsvm" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="lombok" withSubpackages="true" static="false" />
             <emptyLine />
             <package name="lti" withSubpackages="true" static="false" />
             <emptyLine />

--- a/config/formatters/intellij-java-google-style.xml
+++ b/config/formatters/intellij-java-google-style.xml
@@ -1,276 +1,289 @@
 <code_scheme name="GoogleStyle">
-  <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
-  <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
-  <option name="IMPORT_LAYOUT_TABLE">
-    <value>
-      <package name="com.google" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="android" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="antenna" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="antlr" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="ar" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="asposewobfuscated" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="asquare" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="atg" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="au" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="beaver" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="bibtex" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="bmsi" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="bsh" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="ccl" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="cern" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="ChartDirector" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="checkers" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="com" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="COM" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="common" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="contribs" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="corejava" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="cryptix" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="cybervillains" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="dalvik" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="danbikel" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="de" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="EDU" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="eg" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="eu" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="examples" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="fat" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="fit" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="fitlibrary" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="fmpp" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="freemarker" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="gnu" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="groovy" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="groovyjarjarantlr" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="groovyjarjarasm" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="hak" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="hep" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="ie" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="imageinfo" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="info" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="it" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jal" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="Jama" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="japa" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="japacheckers" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jas" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jasmin" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="javancss" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="javanet" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="javassist" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="javazoom" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="java_cup" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jcifs" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jetty" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="JFlex" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jj2000" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jline" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jp" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="JSci" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jsr166y" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="junit" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jxl" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="jxxload_help" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="kawa" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="kea" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="libcore" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="libsvm" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="lombok" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="lti" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="memetic" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="mt" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="mx4j" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="net" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="netscape" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="nl" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="nu" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="oauth" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="ognl" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="opennlp" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="oracle" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="org" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="penn2dg" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="pennconverter" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="pl" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="prefuse" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="proguard" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="repackage" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="scm" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="se" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="serp" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="simple" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="soot" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="sqlj" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="src" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="ssa" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="sun" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="sunlabs" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="tcl" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="testdata" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="testshell" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="testsuite" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="twitter4j" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="uk" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="ViolinStrings" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="weka" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="wet" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="winstone" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="woolfel" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="wowza" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="java" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="javax" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="" withSubpackages="true" static="false" />
-      <emptyLine />
-      <package name="" withSubpackages="true" static="true" />
-    </value>
-  </option>
-  <option name="JD_P_AT_EMPTY_LINES" value="false" />
-  <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
-  <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
-  <option name="JD_KEEP_EMPTY_RETURN" value="false" />
-  <JavaCodeStyleSettings>
-    <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true" />
-  </JavaCodeStyleSettings>
-  <XML>
-    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
-  </XML>
-  <codeStyleSettings language="JAVA">
-    <option name="RIGHT_MARGIN" value="100" />
-    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
-    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
-    <option name="EXTENDS_LIST_WRAP" value="1" />
-    <option name="THROWS_LIST_WRAP" value="1" />
-    <option name="EXTENDS_KEYWORD_WRAP" value="1" />
-    <option name="THROWS_KEYWORD_WRAP" value="1" />
-    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
-    <option name="BINARY_OPERATION_WRAP" value="1" />
-    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
-    <option name="TERNARY_OPERATION_WRAP" value="1" />
-    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
-    <option name="FOR_STATEMENT_WRAP" value="1" />
-    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="ASSIGNMENT_WRAP" value="5" />
-    <option name="IF_BRACE_FORCE" value="3" />
-    <option name="DOWHILE_BRACE_FORCE" value="3" />
-    <option name="WHILE_BRACE_FORCE" value="3" />
-    <option name="FOR_BRACE_FORCE" value="3" />
-  </codeStyleSettings>
+
+    <!--
+
+    File downloaded from https://github.com/google/styleguide/pull/75/files (original formatter for IDEA with some
+    additional fixes for IDEA 14/15.
+
+    -->
+
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99"/>
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99"/>
+    <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+            <package name="com.google" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="android" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="antenna" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="antlr" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="ar" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="asposewobfuscated" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="asquare" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="atg" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="au" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="beaver" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="bibtex" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="bmsi" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="bsh" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="ccl" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="cern" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="ChartDirector" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="checkers" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="com" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="COM" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="common" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="contribs" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="corejava" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="cryptix" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="cybervillains" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="dalvik" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="danbikel" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="de" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="EDU" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="eg" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="eu" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="examples" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="fat" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="fit" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="fitlibrary" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="fmpp" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="freemarker" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="gnu" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="groovy" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="groovyjarjarantlr" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="groovyjarjarasm" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="hak" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="hep" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="ie" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="imageinfo" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="info" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="it" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="jal" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="Jama" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="japa" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="japacheckers" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="jas" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="jasmin" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="javancss" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="javanet" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="javassist" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="javazoom" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="java_cup" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="jcifs" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="jetty" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="JFlex" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="jj2000" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="jline" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="jp" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="JSci" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="jsr166y" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="junit" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="jxl" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="jxxload_help" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="kawa" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="kea" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="libcore" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="libsvm" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="lombok" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="lti" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="memetic" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="mt" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="mx4j" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="net" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="netscape" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="nl" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="nu" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="oauth" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="ognl" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="opennlp" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="oracle" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="org" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="penn2dg" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="pennconverter" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="pl" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="prefuse" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="proguard" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="repackage" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="scm" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="se" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="serp" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="simple" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="soot" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="sqlj" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="src" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="ssa" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="sun" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="sunlabs" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="tcl" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="testdata" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="testshell" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="testsuite" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="twitter4j" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="uk" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="ViolinStrings" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="weka" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="wet" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="winstone" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="woolfel" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="wowza" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="java" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="javax" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="" withSubpackages="true" static="false"/>
+            <emptyLine/>
+            <package name="" withSubpackages="true" static="true"/>
+        </value>
+    </option>
+    <option name="JD_P_AT_EMPTY_LINES" value="false"/>
+    <option name="JD_KEEP_EMPTY_PARAMETER" value="false"/>
+    <option name="JD_KEEP_EMPTY_EXCEPTION" value="false"/>
+    <option name="JD_KEEP_EMPTY_RETURN" value="false"/>
+    <JavaCodeStyleSettings>
+        <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true"/>
+    </JavaCodeStyleSettings>
+    <XML>
+        <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true"/>
+    </XML>
+    <codeStyleSettings language="JAVA">
+        <option name="RIGHT_MARGIN" value="100"/>
+        <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false"/>
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
+        <option name="CALL_PARAMETERS_WRAP" value="1"/>
+        <option name="METHOD_PARAMETERS_WRAP" value="1"/>
+        <option name="EXTENDS_LIST_WRAP" value="1"/>
+        <option name="THROWS_LIST_WRAP" value="1"/>
+        <option name="EXTENDS_KEYWORD_WRAP" value="1"/>
+        <option name="THROWS_KEYWORD_WRAP" value="1"/>
+        <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
+        <option name="BINARY_OPERATION_WRAP" value="1"/>
+        <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true"/>
+        <option name="TERNARY_OPERATION_WRAP" value="1"/>
+        <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
+        <option name="FOR_STATEMENT_WRAP" value="1"/>
+        <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
+        <option name="ASSIGNMENT_WRAP" value="5"/>
+        <option name="IF_BRACE_FORCE" value="3"/>
+        <option name="DOWHILE_BRACE_FORCE" value="3"/>
+        <option name="WHILE_BRACE_FORCE" value="3"/>
+        <option name="FOR_BRACE_FORCE" value="3"/>
+        <indentOptions>
+            <option name="INDENT_SIZE" value="4"/>
+            <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+            <option name="TAB_SIZE" value="4"/>
+        </indentOptions>
+    </codeStyleSettings>
 </code_scheme>

--- a/config/formatters/intellij-java-google-style.xml
+++ b/config/formatters/intellij-java-google-style.xml
@@ -11,7 +11,7 @@
     <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99"/>
     <option name="IMPORT_LAYOUT_TABLE">
         <value>
-            <package name="com.google" withSubpackages="true" static="false"/>
+            <package name="akka" withSubpackages="true" static="false"/>
             <emptyLine/>
             <package name="android" withSubpackages="true" static="false"/>
             <emptyLine/>
@@ -254,6 +254,7 @@
     <option name="JD_KEEP_EMPTY_RETURN" value="false"/>
     <JavaCodeStyleSettings>
         <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true"/>
+        <option name="ANNOTATION_PARAMETER_WRAP" value="1"/>
     </JavaCodeStyleSettings>
     <XML>
         <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true"/>
@@ -284,6 +285,11 @@
             <option name="INDENT_SIZE" value="4"/>
             <option name="CONTINUATION_INDENT_SIZE" value="4"/>
             <option name="TAB_SIZE" value="4"/>
+        </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="Groovy">
+        <indentOptions>
+            <option name="LABEL_INDENT_SIZE" value="4"/>
         </indentOptions>
     </codeStyleSettings>
 </code_scheme>

--- a/config/formatters/intellij-java-google-style.xml
+++ b/config/formatters/intellij-java-google-style.xml
@@ -1,0 +1,286 @@
+<!--
+
+File downloaded from https://github.com/google/styleguide/pull/75/files (original formatter for IDEA with some
+additional fixes for IDEA 14/15.
+
+-->
+
+<code_scheme name="GoogleStyle">
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+    <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+            <package name="com.google" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="android" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="antenna" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="antlr" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="ar" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="asposewobfuscated" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="asquare" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="atg" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="au" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="beaver" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="bibtex" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="bmsi" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="bsh" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="ccl" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="cern" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="ChartDirector" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="checkers" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="com" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="COM" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="common" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="contribs" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="corejava" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="cryptix" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="cybervillains" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="dalvik" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="danbikel" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="de" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="EDU" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="eg" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="eu" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="examples" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="fat" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="fit" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="fitlibrary" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="fmpp" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="freemarker" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="gnu" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="groovy" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="groovyjarjarantlr" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="groovyjarjarasm" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="hak" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="hep" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="ie" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="imageinfo" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="info" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="it" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="jal" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="Jama" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="japa" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="japacheckers" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="jas" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="jasmin" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="javancss" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="javanet" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="javassist" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="javazoom" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="java_cup" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="jcifs" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="jetty" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="JFlex" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="jj2000" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="jline" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="jp" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="JSci" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="jsr166y" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="junit" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="jxl" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="jxxload_help" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="kawa" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="kea" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="libcore" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="libsvm" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="lti" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="memetic" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="mt" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="mx4j" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="net" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="netscape" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="nl" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="nu" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="oauth" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="ognl" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="opennlp" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="oracle" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="org" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="penn2dg" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="pennconverter" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="pl" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="prefuse" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="proguard" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="repackage" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="scm" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="se" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="serp" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="simple" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="soot" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="sqlj" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="src" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="ssa" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="sun" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="sunlabs" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="tcl" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="testdata" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="testshell" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="testsuite" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="twitter4j" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="uk" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="ViolinStrings" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="weka" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="wet" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="winstone" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="woolfel" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="wowza" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="java" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="javax" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="" withSubpackages="true" static="false" />
+            <emptyLine />
+            <package name="" withSubpackages="true" static="true" />
+        </value>
+    </option>
+    <option name="JD_P_AT_EMPTY_LINES" value="false" />
+    <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
+    <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
+    <option name="JD_KEEP_EMPTY_RETURN" value="false" />
+    <JavaCodeStyleSettings>
+        <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true" />
+    </JavaCodeStyleSettings>
+    <XML>
+        <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+    </XML>
+    <codeStyleSettings language="JAVA">
+        <option name="RIGHT_MARGIN" value="100" />
+        <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+        <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+        <option name="CALL_PARAMETERS_WRAP" value="1" />
+        <option name="METHOD_PARAMETERS_WRAP" value="1" />
+        <option name="EXTENDS_LIST_WRAP" value="1" />
+        <option name="THROWS_LIST_WRAP" value="1" />
+        <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+        <option name="THROWS_KEYWORD_WRAP" value="1" />
+        <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+        <option name="BINARY_OPERATION_WRAP" value="1" />
+        <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+        <option name="TERNARY_OPERATION_WRAP" value="1" />
+        <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+        <option name="FOR_STATEMENT_WRAP" value="1" />
+        <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+        <option name="ASSIGNMENT_WRAP" value="5" />
+        <option name="IF_BRACE_FORCE" value="3" />
+        <option name="DOWHILE_BRACE_FORCE" value="3" />
+        <option name="WHILE_BRACE_FORCE" value="3" />
+        <option name="FOR_BRACE_FORCE" value="3" />
+        <indentOptions>
+            <option name="INDENT_SIZE" value="2" />
+            <option name="CONTINUATION_INDENT_SIZE" value="4" />
+            <option name="TAB_SIZE" value="8" />
+        </indentOptions>
+    </codeStyleSettings>
+</code_scheme>

--- a/config/formatters/scripts/copyIdeaFormatterMacOS.sh
+++ b/config/formatters/scripts/copyIdeaFormatterMacOS.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+cp ../intellij-java-google-style.xml ~/Library/Preferences/IntelliJIdea15/codestyles


### PR DESCRIPTION
This is a WIP towards common formatting rules.

1. New checkstyle based on Google Java Style Guide 

Changes there (as in commits in this PR):
 - Raise errors when checkstyle fails
 - Classes from google.com are no longer treated in a special way in import ordering
 - Indentation is based on 4-spaces (Google currently advices 2-spaces base indentation)
 - Javadocs are not required

There are two Eclipse/IntelliJ formatters that are currently almost in line with checkstyle checks. They will requires some tuning (especially indentation and import ordering) but we need to agree on the checkstyle file first.
 
Things that I want to discuss (taken from failing checkstyle report):
1. If you have any comments to the changes already applied to the original checkstyle file, please write them in this topic.
2. `Line is longer than 100 characters (found 113). [LineLength]` - is 100 a good number? I have a feeling that it is a bit too low :)
3. `'.' should be on a new line. [SeparatorWrap]`:

        authFeature = HttpAuthenticationFeature.
            basicBuilder().
            nonPreemptive().
            credentials("api", malingApiKey).
            build();
Do we have any preferences here? `.` on a new line looks reasonable fix to this code. 
4. `Package name 'pl.tomaszdziurko.jvm_bloggers.blog_posts' must match pattern '^[a-z]+(\.[a-z][a-z0-9]*)*$'. [PackageName]` - I would like to allow `_` in package names as they are more readable than `blogposts` What do you think?
5. There is still a problem in breaking lines strategy. But it will be hard to standarise I think.

If you spot anything else in checkstyle.xml, please also raise it here.
