### PR TITLE
issue/#118 Blog posts sorted by (approved, publishedDate)

### DIFF
--- a/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/domain/BlogPost.java
+++ b/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/domain/BlogPost.java
@@ -70,6 +70,10 @@ public class BlogPost {
         return Boolean.FALSE.equals(approved);
     }
 
+    public boolean isNotModerated() {
+        return approved == null;
+    }
+
     public String getApprovalState() {
         if (approved == null) {
             return " -- ";

--- a/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/domain/BlogPostRepository.java
+++ b/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/domain/BlogPostRepository.java
@@ -19,7 +19,7 @@ public interface BlogPostRepository extends JpaRepository<BlogPost, Long> {
 
     List<BlogPost> findByApprovedTrueOrderByPublishedDateDesc();
 
-    @Query("from BlogPost bp order by bp.publishedDate desc")
+    @Query("from BlogPost bp order by bp.approved nulls first, bp.publishedDate desc")
     List<BlogPost> findLatestPosts(Pageable page);
 
     int countByPublishedDateAfter(LocalDateTime publishedDate);

--- a/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/blog_posts/domain/BlogPostRepositorySpec.groovy
+++ b/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/blog_posts/domain/BlogPostRepositorySpec.groovy
@@ -37,7 +37,7 @@ class BlogPostRepositorySpec extends SpringContextAwareSpecification {
                 aBlogPost(6, LocalDateTime.of(2016, 1, 6, 12, 00), NOT_MODERATED, blog)
             ]
 
-            blogPosts.each { blogPost -> blogPostRepository.save(blogPost) }
+            blogPostRepository.save(blogPosts)
         when:
             def latestPosts = blogPostRepository.findLatestPosts(new PageRequest(0, blogPosts.size()))
         then:

--- a/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/blog_posts/domain/BlogPostRepositorySpec.groovy
+++ b/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/blog_posts/domain/BlogPostRepositorySpec.groovy
@@ -1,0 +1,65 @@
+package pl.tomaszdziurko.jvm_bloggers.blog_posts.domain
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.PageRequest
+import org.springframework.test.context.ActiveProfiles
+import pl.tomaszdziurko.jvm_bloggers.SpringContextAwareSpecification
+import pl.tomaszdziurko.jvm_bloggers.blogs.domain.Blog
+import pl.tomaszdziurko.jvm_bloggers.blogs.domain.BlogRepository
+
+import java.time.LocalDateTime
+
+import static pl.tomaszdziurko.jvm_bloggers.blogs.domain.BlogType.PERSONAL
+
+@ActiveProfiles("test")
+class BlogPostRepositorySpec extends SpringContextAwareSpecification {
+
+    static NOT_MODERATED = null
+    static APPROVED = Boolean.TRUE
+    static REJECTED = Boolean.FALSE
+
+    @Autowired
+    BlogPostRepository blogPostRepository
+
+    @Autowired
+    BlogRepository blogRepository
+
+    def "Should order latest posts by moderation and publication date"() {
+        given:
+            def blog = aBlog()
+
+            def blogPosts = [
+                aBlogPost(1, LocalDateTime.of(2016, 1, 1, 12, 00), REJECTED, blog),
+                aBlogPost(2, LocalDateTime.of(2016, 1, 4, 12, 00), REJECTED, blog),
+                aBlogPost(3, LocalDateTime.of(2016, 1, 2, 12, 00), APPROVED, blog),
+                aBlogPost(4, LocalDateTime.of(2016, 1, 5, 12, 00), APPROVED, blog),
+                aBlogPost(5, LocalDateTime.of(2016, 1, 3, 12, 00), NOT_MODERATED, blog),
+                aBlogPost(6, LocalDateTime.of(2016, 1, 6, 12, 00), NOT_MODERATED, blog)
+            ]
+
+            blogPosts.each { blogPost -> blogPostRepository.save(blogPost) }
+        when:
+            def latestPosts = blogPostRepository.findLatestPosts(new PageRequest(0, blogPosts.size()))
+        then:
+            latestPosts[0].isNotModerated()
+            latestPosts[1].isNotModerated()
+            latestPosts[0].getPublishedDate().isAfter(latestPosts[1].getPublishedDate())
+
+            latestPosts[2].isRejected()
+            latestPosts[3].isRejected()
+            latestPosts[2].getPublishedDate().isAfter(latestPosts[3].getPublishedDate())
+
+            latestPosts[4].isApproved()
+            latestPosts[5].isApproved()
+            latestPosts[4].getPublishedDate().isAfter(latestPosts[5].getPublishedDate())
+    }
+
+    private Blog aBlog() {
+        def blog = new Blog(jsonId: 1L, author: "Top Blogger", rss: "http://topblogger.pl/", dateAdded: LocalDateTime.now(), blogType: PERSONAL)
+        return blogRepository.save(blog)
+    }
+
+    private BlogPost aBlogPost(final int index, final LocalDateTime publishedDate, final Boolean approved, final Blog blog) {
+        return new BlogPost(publishedDate: publishedDate, approved: approved, blog: blog, title: "title" + index, url: "url" + index)
+    }
+}


### PR DESCRIPTION
Just included _approved_ property in _order by_ clause.

Posts are correctly sorted because of the following positioning of NULL value:
> By default, null values sort as if larger than any non-null value; that is, NULLS FIRST is the default for DESC order, and NULLS LAST otherwise.