### PR TITLE
Added support for limiting generated RSS feed entries count, fixes #154

### DIFF
--- a/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/AggregatedRssFeedProducer.java
+++ b/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/AggregatedRssFeedProducer.java
@@ -1,6 +1,7 @@
 package pl.tomaszdziurko.jvm_bloggers.blog_posts;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.rometools.rome.feed.synd.SyndContentImpl;
 import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndEntryImpl;
@@ -12,6 +13,7 @@ import com.rometools.rome.feed.synd.SyndLinkImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
@@ -37,7 +39,6 @@ import static pl.tomaszdziurko.jvm_bloggers.utils.DateTimeUtilities.toDate;
 public class AggregatedRssFeedProducer {
 
     public static final String RSS_CACHE = "Aggregated RSS feed cache";
-    private static final String RSS_CACHE_KEY = "'rss_cache_key'";
     private static final String SELF_REL = "self";
 
     @VisibleForTesting
@@ -54,8 +55,23 @@ public class AggregatedRssFeedProducer {
     private final BlogPostRepository blogPostRepository;
     private final NowProvider nowProvider;
 
-    @Cacheable(key = RSS_CACHE_KEY)
-    public SyndFeed getRss(String requestedUrlString) {
+    /**
+     * Generates aggregated RSS feed for all or given <tt>limit</tt> of approved blog posts.
+     *
+     * @param feedUrl Value of the <tt>{@literal <link rel=self/>}</tt> element
+     *     of the generated feed. It identifies the URL of the web site associated
+     *     with the generated feed. Cannot be <tt>null</tt> nor empty.
+     *
+     * @param limit Upper limit of RSS entries count in the generated feed. If equal or less
+     *     than zero then all approved blog posts will be generated.
+     *
+     * @return Aggregated RSS feed for approved blog posts ordered by publication date
+     */
+    @Cacheable
+    public SyndFeed getRss(String feedUrl, long limit) {
+
+        Preconditions.checkArgument(
+            StringUtils.isNotBlank(feedUrl), "feedUrl parameter cannot be blank");
 
         final StopWatch stopWatch = new StopWatch();
         log.debug("Building aggregated RSS feed...");
@@ -65,9 +81,10 @@ public class AggregatedRssFeedProducer {
             blogPostRepository.findByApprovedTrueOrderByPublishedDateDesc();
         final List<SyndEntry> feedItems = approvedPosts.stream()
             .map(this::toRssEntry)
+            .limit(limit > 0 ? limit : Long.MAX_VALUE)
             .collect(Collectors.toList());
 
-        final SyndFeed feed = buildFeed(feedItems, requestedUrlString);
+        final SyndFeed feed = buildFeed(feedItems, feedUrl);
 
         stopWatch.stop();
         log.info("Total {} feed entries produced in {}ms", feedItems.size(),

--- a/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/BlogPostsController.java
+++ b/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/BlogPostsController.java
@@ -28,8 +28,8 @@ public class BlogPostsController {
     @SneakyThrows
     @RequestMapping("/pl/rss")
     public void getRss(HttpServletRequest request, HttpServletResponse response,
-        PrintWriter writer, @RequestParam(required = false) Long limit,
-        @Value("${generated.rss.entries.limit}") long defaultLimit) {
+        PrintWriter writer, @RequestParam(required = false) Integer limit,
+        @Value("${generated.rss.entries.limit}") int defaultLimit) {
         limit = firstNonNull(limit, defaultLimit);
         response.setContentType(MediaType.APPLICATION_ATOM_XML_VALUE);
         new SyndFeedOutput().output(

--- a/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/BlogPostsController.java
+++ b/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/BlogPostsController.java
@@ -6,14 +6,18 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.PrintWriter;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
 
 @RestController
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -24,10 +28,12 @@ public class BlogPostsController {
     @SneakyThrows
     @RequestMapping("/pl/rss")
     public void getRss(HttpServletRequest request, HttpServletResponse response,
-            PrintWriter writer) {
+        PrintWriter writer, @RequestParam(required = false) Long limit,
+        @Value("${generated.rss.entries.limit}") long defaultLimit) {
+        limit = firstNonNull(limit, defaultLimit);
         response.setContentType(MediaType.APPLICATION_ATOM_XML_VALUE);
         new SyndFeedOutput().output(
-            rssProducer.getRss(request.getRequestURL().toString()),
+            rssProducer.getRss(request.getRequestURL().toString(), limit),
             writer
         );
     }

--- a/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/domain/BlogPostRepository.java
+++ b/src/main/java/pl/tomaszdziurko/jvm_bloggers/blog_posts/domain/BlogPostRepository.java
@@ -17,7 +17,7 @@ public interface BlogPostRepository extends JpaRepository<BlogPost, Long> {
     List<BlogPost> findByPublishedDateAfterAndApprovedTrueOrderByPublishedDateAsc(
         LocalDateTime publishedDate);
 
-    List<BlogPost> findByApprovedTrueOrderByPublishedDateDesc();
+    List<BlogPost> findByApprovedTrueOrderByPublishedDateDesc(Pageable page);
 
     @Query("from BlogPost bp order by "
            + "case when bp.approved is null then 0 else 1 end, "

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,6 +14,7 @@ server.compression:
  
 bloggers.data.file.url: https://raw.githubusercontent.com/tdziurko/jvm-bloggers/master/bloggers.json
 companies.data.file.url: https://raw.githubusercontent.com/tdziurko/jvm-bloggers/master/companies.json
+generated.rss.entries.limit: 100
 
 # Logging
 logging.level.root: INFO

--- a/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/blog_posts/AggregatedRssFeedProducerSpec.groovy
+++ b/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/blog_posts/AggregatedRssFeedProducerSpec.groovy
@@ -18,15 +18,23 @@ class AggregatedRssFeedProducerSpec extends Specification {
 
     def EXPECTED_UTM_SUBSTRING = "?utm_source=jvm-bloggers.com&utm_medium=RSS&utm_campaign=RSS"
     def DESCRIPTION = "description"
-    def TITLE = "title"
-    def URL = "http://blogPostUrl"
-    def AUTHOR = "author"
+    def TITLE_1 = "title_1"
+    def TITLE_2 = "title_2"
+    def URL_1 = "http://blogPostUrl_1"
+    def URL_2 = "http://blogPostUrl_2"
+    def AUTHOR_1 = "author_1"
+    def AUTHOR_2 = "author_2"
     def DATE = new NowProvider().now()
     def UID_1 = UUID.randomUUID().toString()
     def UID_2 = UUID.randomUUID().toString()
     def REQUEST_URL = "http://jvm-bloggers.com/rss"
 
-    BlogPostRepository blogPostRepository = Mock()
+    BlogPostRepository blogPostRepository = Stub() {
+        BlogPost blogPost1 = stubBlogPost(UID_1, DESCRIPTION, TITLE_1, URL_1, AUTHOR_1, DATE)
+        BlogPost blogPost2 = stubBlogPost(UID_2, null, TITLE_2, URL_2, AUTHOR_2, DATE)
+        findByApprovedTrueOrderByPublishedDateDesc() >> [blogPost1, blogPost2]
+    }
+    
     NowProvider nowProvider = Stub() {
         now() >> DATE
     }
@@ -34,13 +42,9 @@ class AggregatedRssFeedProducerSpec extends Specification {
     @Subject
     AggregatedRssFeedProducer rssProducer = new AggregatedRssFeedProducer(blogPostRepository, nowProvider)
 
-    def "Should produce aggregated RSS feed"() {
-        given:
-            BlogPost blogPost1 = mockBlogPost(UID_1, DESCRIPTION, TITLE, URL, AUTHOR, DATE)
-            BlogPost blogPost2 = mockBlogPost(UID_2, null, TITLE, URL, AUTHOR, DATE)
-            1 * blogPostRepository.findByApprovedTrueOrderByPublishedDateDesc() >> [blogPost1, blogPost2]
+    def "Should produce aggregated RSS feed with all entries"() {
         when:
-            SyndFeed feed = rssProducer.getRss(REQUEST_URL)
+            SyndFeed feed = rssProducer.getRss(REQUEST_URL, 0)
         then:
             Date date = toDate(DATE)
             with (feed) {
@@ -55,36 +59,76 @@ class AggregatedRssFeedProducerSpec extends Specification {
             }
         and:
             with (feed.entries[0]) {
-                link == URL + EXPECTED_UTM_SUBSTRING
-                title == TITLE
-                author == AUTHOR
+                link == URL_1 + EXPECTED_UTM_SUBSTRING
+                title == TITLE_1
+                author == AUTHOR_1
                 description.value == DESCRIPTION
                 publishedDate == date
-                author == AUTHOR
+                author == AUTHOR_1
+                uri == UID_1
             }
         and:
             with (feed.entries[1]) {
-                link == URL + EXPECTED_UTM_SUBSTRING
-                title == TITLE
-                author == AUTHOR
+                link == URL_2 + EXPECTED_UTM_SUBSTRING
+                title == TITLE_2
+                author == AUTHOR_2
                 description == null
                 publishedDate == date
-                author == AUTHOR
+                author == AUTHOR_2
+                uri == UID_2
             }
 
     }
 
-    def mockBlogPost(String uid, String description, String title, String url, String author, LocalDateTime date) {
-        BlogPost blogPost = Mock()
-        1 * blogPost.getDescription() >> description
-        1 * blogPost.getTitle() >> title
-        1 * blogPost.getUrl() >> url
-        1 * blogPost.getUid() >> uid 
-        Blog blog = Mock()
-        blog.getAuthor() >> author
-        1 * blogPost.getBlog() >> blog
-        1 * blogPost.getPublishedDate() >> date
-        return blogPost
+    def "Should produce aggregated RSS feed with limited entries count"() {
+        when:
+            SyndFeed feed = rssProducer.getRss(REQUEST_URL, 1)
+        then:
+            Date date = toDate(DATE)
+            with (feed) {
+                links[0].rel == "self"
+                links[0].href == REQUEST_URL
+                feedType == AggregatedRssFeedProducer.FEED_TYPE
+                uri == AggregatedRssFeedProducer.FEED_TITLE
+                title == AggregatedRssFeedProducer.FEED_TITLE
+                description == AggregatedRssFeedProducer.FEED_DESCRIPTION
+                publishedDate == date
+                entries.size() == 1
+            }
+        and:
+            with (feed.entries[0]) {
+                link == URL_1 + EXPECTED_UTM_SUBSTRING
+                title == TITLE_1
+                author == AUTHOR_1
+                description.value == DESCRIPTION
+                publishedDate == date
+                author == AUTHOR_1
+            }
+
+    }
+
+    def "Should throw IAE on blank feedUrl parameter"() {
+        when:
+            rssProducer.getRss(blankFeedUrl, 1)
+        then:
+            IllegalArgumentException e = thrown()
+            e.getMessage() == "feedUrl parameter cannot be blank"
+        where:
+            blankFeedUrl << [" ", "", null]
+    }
+
+    def stubBlogPost(String uid, String description, String title, String url, String author, LocalDateTime date) {
+        Blog blog = Stub() {
+            getAuthor() >> author
+        }
+        return Stub(BlogPost) {
+            getDescription() >> description
+            getTitle() >> title
+            getUrl() >> url
+            getUid() >> uid 
+            getBlog() >> blog
+            getPublishedDate() >> date
+        }
     }
 
 }

--- a/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/blog_posts/AggregatedRssFeedProducerSpec.groovy
+++ b/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/blog_posts/AggregatedRssFeedProducerSpec.groovy
@@ -1,12 +1,14 @@
 package pl.tomaszdziurko.jvm_bloggers.blog_posts
 
 import com.rometools.rome.feed.synd.SyndFeed
+import org.springframework.data.domain.Pageable
 import pl.tomaszdziurko.jvm_bloggers.blog_posts.domain.BlogPost
 import pl.tomaszdziurko.jvm_bloggers.blog_posts.domain.BlogPostRepository
 import pl.tomaszdziurko.jvm_bloggers.blogs.domain.Blog
 import pl.tomaszdziurko.jvm_bloggers.utils.NowProvider
 import spock.lang.Specification
 import spock.lang.Subject
+import spock.lang.Unroll
 
 import java.time.LocalDateTime
 
@@ -16,25 +18,30 @@ import static pl.tomaszdziurko.jvm_bloggers.utils.DateTimeUtilities.toDate
 
 class AggregatedRssFeedProducerSpec extends Specification {
 
-    def EXPECTED_UTM_SUBSTRING = "?utm_source=jvm-bloggers.com&utm_medium=RSS&utm_campaign=RSS"
-    def DESCRIPTION = "description"
-    def TITLE_1 = "title_1"
-    def TITLE_2 = "title_2"
-    def URL_1 = "http://blogPostUrl_1"
-    def URL_2 = "http://blogPostUrl_2"
-    def AUTHOR_1 = "author_1"
-    def AUTHOR_2 = "author_2"
-    def DATE = new NowProvider().now()
-    def UID_1 = UUID.randomUUID().toString()
-    def UID_2 = UUID.randomUUID().toString()
-    def REQUEST_URL = "http://jvm-bloggers.com/rss"
+    String EXPECTED_UTM_SUBSTRING = "?utm_source=jvm-bloggers.com&utm_medium=RSS&utm_campaign=RSS"
+    String DESCRIPTION = "description"
+    String TITLE_1 = "title_1"
+    String TITLE_2 = "title_2"
+    String URL_1 = "http://blogPostUrl_1"
+    String URL_2 = "http://blogPostUrl_2"
+    String AUTHOR_1 = "author_1"
+    String AUTHOR_2 = "author_2"
+    LocalDateTime DATE = new NowProvider().now()
+    String UID_1 = UUID.randomUUID().toString()
+    String UID_2 = UUID.randomUUID().toString()
+    String REQUEST_URL = "http://jvm-bloggers.com/rss"
 
     BlogPostRepository blogPostRepository = Stub() {
         BlogPost blogPost1 = stubBlogPost(UID_1, DESCRIPTION, TITLE_1, URL_1, AUTHOR_1, DATE)
         BlogPost blogPost2 = stubBlogPost(UID_2, null, TITLE_2, URL_2, AUTHOR_2, DATE)
-        findByApprovedTrueOrderByPublishedDateDesc() >> [blogPost1, blogPost2]
+        findByApprovedTrueOrderByPublishedDateDesc(_) >> { args ->
+            Pageable pageable = args[0]
+            List<BlogPost> blogposts = [blogPost1, blogPost2]
+            int limit = Math.min(blogposts.size(), pageable.pageSize)
+            return blogposts.subList(0, limit)
+        }
     }
-    
+
     NowProvider nowProvider = Stub() {
         now() >> DATE
     }
@@ -107,7 +114,8 @@ class AggregatedRssFeedProducerSpec extends Specification {
 
     }
 
-    def "Should throw IAE on blank feedUrl parameter"() {
+    @Unroll
+    def "Should throw IAE on invalid feedUrl = [#blankFeedUrl]"() {
         when:
             rssProducer.getRss(blankFeedUrl, 1)
         then:

--- a/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/blog_posts/BlogPostsControllerSpec.groovy
+++ b/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/blog_posts/BlogPostsControllerSpec.groovy
@@ -29,7 +29,7 @@ class BlogPostsControllerSpec extends Specification {
         feed.description = AggregatedRssFeedProducer.FEED_DESCRIPTION
         feed.publishedDate = today
         feed.entries = [createSyndEntry("postId", "postUrl", "postTitle",  "postAuthor", "postDescription", today)]
-        1 * getRss(_) >> feed
+        1 * getRss(_, _) >> feed
     }
 
     @Subject
@@ -43,7 +43,7 @@ class BlogPostsControllerSpec extends Specification {
             HttpServletResponse response = Mock()
             def actualOutput = new ByteArrayOutputStream()
         when:
-            blogPostsController.getRss(request, response, new PrintWriter(actualOutput))
+            blogPostsController.getRss(request, response, new PrintWriter(actualOutput), null, 0)
         then:
             1 * response.setContentType(MediaType.APPLICATION_ATOM_XML_VALUE)
             def actualLines = IOUtils.readLines(IOUtils.toInputStream(actualOutput.toString()))


### PR DESCRIPTION
- the limit is configurable by `generated.rss.entries.limit` property in [`application.yaml`](https://github.com/goostleek/jvm-bloggers/blob/issue/%23154/limit-rss-entries/src/main/resources/application.yaml#L17)
- RSS consumer can override the limit on HTTP request level by appending `limit` query parameter, eg:
  - `http://localhost:8080/pl/rss?limit=10`
  - `http://localhost:8080/pl/rss?limit=0` to get all approved blog entries