### PR TITLE
MockSpringContextAwareSpecification introduced

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ dependencies {
     compile 'org.antlr:ST4:4.0.8'
     compile 'org.glassfish.jersey.core:jersey-client:2.22.2'
     compile 'net.jcip:jcip-annotations:1.0'
+    compile 'org.objenesis:objenesis:2.2'
 
     // Database related
     compile "org.postgresql:postgresql:9.4.1208.jre7"

--- a/src/main/java/pl/tomaszdziurko/jvm_bloggers/view/login/attack/stream/BruteForceAttackEventStreamManager.java
+++ b/src/main/java/pl/tomaszdziurko/jvm_bloggers/view/login/attack/stream/BruteForceAttackEventStreamManager.java
@@ -2,6 +2,7 @@ package pl.tomaszdziurko.jvm_bloggers.view.login.attack.stream;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -33,27 +34,22 @@ import javax.annotation.PreDestroy;
  */
 @Slf4j
 @Component
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class BruteForceAttackEventStreamManager {
 
     @VisibleForTesting
     public static final int MAILING_TIME_THROTTLE_IN_MINUTES = 1;
 
-    private static final int INITIAL_CAPACITY = 256;
-
     private final ConcurrentMap<String, BruteForceAttackEventStream> streamMap =
-        new ConcurrentHashMap<>(INITIAL_CAPACITY);
+        new ConcurrentHashMap<>();
 
-    @Autowired
-    private MailSender mailSender;
+    private final MailSender mailSender;
 
-    @Autowired
-    private BruteForceAttackMailGenerator bruteForceAttackMailGenerator;
+    private final BruteForceAttackMailGenerator bruteForceAttackMailGenerator;
 
-    @Autowired
-    private Scheduler scheduler;
+    private final Scheduler scheduler;
 
-    @Autowired
-    private MetadataRepository metadataRepository;
+    private final MetadataRepository metadataRepository;
 
     private String adminEmailAddress;
 

--- a/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/MockSpringContextAwareSpecification.groovy
+++ b/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/MockSpringContextAwareSpecification.groovy
@@ -1,0 +1,36 @@
+package pl.tomaszdziurko.jvm_bloggers
+
+import org.apache.wicket.mock.MockApplication
+import org.apache.wicket.protocol.http.WebApplication
+import org.apache.wicket.spring.injection.annot.SpringComponentInjector
+import org.apache.wicket.spring.test.ApplicationContextMock
+import org.apache.wicket.util.tester.WicketTester
+
+import pl.tomaszdziurko.jvm_bloggers.view.session.UserSession
+
+import spock.lang.Specification
+
+public abstract class MockSpringContextAwareSpecification extends Specification {
+
+    private final ApplicationContextMock mockApplicationContext = new ApplicationContextMock()
+
+    protected final WicketTester tester = new WicketTester([
+        "newSession": {
+            request, response -> new UserSession(request)
+        }
+    ] as MockApplication)
+
+    def setup() {
+        WebApplication webApp = tester.getApplication()
+        webApp.getComponentInstantiationListeners()
+                .add(new SpringComponentInjector(webApp, mockApplicationContext))
+        setupContext()
+    }
+
+    protected abstract void setupContext()
+
+    protected void addBean(Object bean) {
+        mockApplicationContext.putBean(bean)
+    }
+
+}

--- a/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/view/login/LoginPageSpec.groovy
+++ b/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/view/login/LoginPageSpec.groovy
@@ -1,51 +1,70 @@
 package pl.tomaszdziurko.jvm_bloggers.view.login
 
-import org.apache.wicket.protocol.http.WebApplication
+import org.apache.wicket.authroles.authorization.strategies.role.Roles
 import org.apache.wicket.util.tester.FormTester
-import org.apache.wicket.util.tester.WicketTester
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.util.ReflectionTestUtils
-import pl.tomaszdziurko.jvm_bloggers.SpringContextAwareSpecification
-import pl.tomaszdziurko.jvm_bloggers.mailing.LogMailSenderPostAction
+
+import pl.tomaszdziurko.jvm_bloggers.MockSpringContextAwareSpecification
+import pl.tomaszdziurko.jvm_bloggers.blog_posts.domain.BlogPostRepository
 import pl.tomaszdziurko.jvm_bloggers.mailing.LogMailSender
+import pl.tomaszdziurko.jvm_bloggers.mailing.LogMailSenderPostAction
+import pl.tomaszdziurko.jvm_bloggers.metadata.MetadataRepository
+import pl.tomaszdziurko.jvm_bloggers.utils.NowProvider
 import pl.tomaszdziurko.jvm_bloggers.view.admin.AdminDashboardPage
+import pl.tomaszdziurko.jvm_bloggers.view.login.attack.BruteForceAttackMailGenerator
+import pl.tomaszdziurko.jvm_bloggers.view.login.attack.BruteForceLoginAttackDetector
 import pl.tomaszdziurko.jvm_bloggers.view.login.attack.stream.BruteForceAttackEventStreamManager
+
 import rx.schedulers.TestScheduler
 
 import java.util.concurrent.TimeUnit
 
-import static BruteForceAttackEventStreamManager.MAILING_TIME_THROTTLE_IN_MINUTES
+import static pl.tomaszdziurko.jvm_bloggers.view.login.attack.stream.BruteForceAttackEventStreamManager.MAILING_TIME_THROTTLE_IN_MINUTES
 
-class LoginPageSpec extends SpringContextAwareSpecification {
+class LoginPageSpec extends MockSpringContextAwareSpecification {
 
-    private WicketTester tester
+    LogMailSenderPostAction logMailPostAction = new LogMailSenderPostAction()
 
-    @Autowired
-    private WebApplication wicketApplication
+    LogMailSender logMailSender = new LogMailSender(logMailPostAction)
 
-    @Autowired
-    private LogMailSender logMailSender;
+    TestScheduler scheduler = new TestScheduler()
 
-    @Autowired
-    private TestScheduler scheduler;
+    UserAuthenticator userAuthenticator = Stub()
 
-    @Autowired
-    private LogMailSenderPostAction logMailPostAction;
+    Roles adminRoles = Stub() {
+        hasRole(Roles.ADMIN) >> true
+    }
 
-    def setup() {
-        // This is a workaround for problems with Spring Boot and WicketTester
-        // https://issues.apache.org/jira/browse/WICKET-6053 and
-        // https://github.com/MarcGiffing/wicket-spring-boot/issues/31
-        ReflectionTestUtils.setField(wicketApplication, "name", null)
-        tester = new WicketTester(wicketApplication)
+    Roles notAdminRoles = Stub() {
+        hasRole(Roles.ADMIN) >> false
+    }
+
+    def void setupContext() {
+        NowProvider nowProvider = new NowProvider()
+        addBean(nowProvider)
+        addBean(userAuthenticator)
+        addBean(new BruteForceLoginAttackDetector())
+        addBean(new BruteForceAttackEventStreamManager(
+                    logMailSender,
+                    new BruteForceAttackMailGenerator(nowProvider),
+                    scheduler,
+                    Stub(MetadataRepository) {
+                        findByName(_) >> "mail"
+                    }
+                )
+            )
+        addBean(Mock(BlogPostRepository))
     }
 
     def "Should redirect to Admin Dashboard after successful login"() {
+        given:
+            def login = "login"
+            def pass = "pass"
+            userAuthenticator.getRolesForUser(login, pass) >> adminRoles
         when:
             tester.startPage(LoginPage.class)
             FormTester formTester = tester.newFormTester(LoginPage.LOGIN_FORM_ID)
-            formTester.setValue(LoginPage.LOGIN_FIELD_ID, "Any User")
-            formTester.setValue(LoginPage.PASSWORD_FIELD_ID, PASSWORD)
+            formTester.setValue(LoginPage.LOGIN_FIELD_ID, login)
+            formTester.setValue(LoginPage.PASSWORD_FIELD_ID, pass)
             formTester.submit(LoginPage.FORM_SUBMIT_ID)
         then:
             tester.assertNoErrorMessage()
@@ -53,6 +72,8 @@ class LoginPageSpec extends SpringContextAwareSpecification {
     }
 
     def "Should reject incorrect password"() {
+        given:
+            userAuthenticator.getRolesForUser(_, _) >> notAdminRoles
         when:
             tester.startPage(LoginPage.class)
             FormTester formTester = tester.newFormTester(LoginPage.LOGIN_FORM_ID)
@@ -65,6 +86,8 @@ class LoginPageSpec extends SpringContextAwareSpecification {
     }
 
     def "Should not try to login after brute force attack was detected"() {
+        given:
+            userAuthenticator.getRolesForUser(_, _) >> notAdminRoles
         when:
             (1..4).each {
                 tester.startPage(LoginPage.class)
@@ -80,6 +103,7 @@ class LoginPageSpec extends SpringContextAwareSpecification {
 
     def "Should not send e-mail more than twice after multiple brute force attack were detected"() {
         given:
+            userAuthenticator.getRolesForUser(_, _) >> notAdminRoles
             logMailPostAction.actionsToWaitOn(2)
         when:
             (1..10).each {
@@ -90,15 +114,15 @@ class LoginPageSpec extends SpringContextAwareSpecification {
                 formTester.submit(LoginPage.FORM_SUBMIT_ID)
 
                 if (it.intValue() == 5) {
-                    scheduler.advanceTimeTo(MAILING_TIME_THROTTLE_IN_MINUTES, TimeUnit.MINUTES);
+                    scheduler.advanceTimeTo(MAILING_TIME_THROTTLE_IN_MINUTES, TimeUnit.MINUTES)
                 } else if (it.intValue() == 10) {
-                    scheduler.advanceTimeTo(MAILING_TIME_THROTTLE_IN_MINUTES * 2, TimeUnit.MINUTES);
+                    scheduler.advanceTimeTo(MAILING_TIME_THROTTLE_IN_MINUTES * 2, TimeUnit.MINUTES)
                 }
             }
         then:
             tester.assertErrorMessages("Incorrect login or password [BruteForce attack was detected]")
             tester.assertRenderedPage(LoginPage.class)
-            logMailSender.getLogMailSenderPostAction().awaitActions();
+            logMailSender.getLogMailSenderPostAction().awaitActions()
             scheduler.triggerActions()
     }
 }

--- a/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/view/login/LoginPageSpec.groovy
+++ b/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/view/login/LoginPageSpec.groovy
@@ -57,8 +57,8 @@ class LoginPageSpec extends MockSpringContextAwareSpecification {
 
     def "Should redirect to Admin Dashboard after successful login"() {
         given:
-            def login = "login"
-            def pass = "pass"
+            String login = "login"
+            String pass = "pass"
             userAuthenticator.getRolesForUser(login, pass) >> adminRoles
         when:
             tester.startPage(LoginPage.class)

--- a/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/view/login/attack/stream/BruteForceAttackEventStreamManagerSpec.groovy
+++ b/src/test/groovy/pl/tomaszdziurko/jvm_bloggers/view/login/attack/stream/BruteForceAttackEventStreamManagerSpec.groovy
@@ -15,9 +15,7 @@ import spock.lang.Specification
 import java.util.concurrent.TimeUnit
 
 import static BruteForceAttackEventStreamManager.MAILING_TIME_THROTTLE_IN_MINUTES
-/**
- * @author Adam Dec
- */
+
 class BruteForceAttackEventStreamManagerSpec extends Specification {
 
     LogMailSender mailSender;
@@ -27,20 +25,14 @@ class BruteForceAttackEventStreamManagerSpec extends Specification {
     BruteForceAttackEventStreamManager manager;
 
     def setup() {
-        logMailPostAction = new LogMailSenderPostAction();
-        mailSender = new LogMailSender(logMailPostAction)
-        metadataRepository = Mock(MetadataRepository);
-        BruteForceAttackMailGenerator bruteForceAttackMailGenerator = Mock(BruteForceAttackMailGenerator)
-        bruteForceAttackMailGenerator.prepareMailContent(_) >> "A"
-        bruteForceAttackMailGenerator.prepareMailTitle(_) >> "B"
-        scheduler = new TestScheduler()
-
-        // Close your eyes! :D
-        manager = new BruteForceAttackEventStreamManager()
-        ReflectionTestUtils.setField(manager, "mailSender", mailSender)
-        ReflectionTestUtils.setField(manager, "bruteForceAttackMailGenerator", bruteForceAttackMailGenerator)
-        ReflectionTestUtils.setField(manager, "scheduler", scheduler)
-        ReflectionTestUtils.setField(manager, "metadataRepository", metadataRepository)
+        manager = new BruteForceAttackEventStreamManager(
+            mailSender = new LogMailSender(logMailPostAction = new LogMailSenderPostAction()),
+            Mock(BruteForceAttackMailGenerator) {
+                prepareMailTitle(_) >> "mail title"
+                prepareMailContent(_) >> "mail content"
+            },
+            scheduler = new TestScheduler(),
+            metadataRepository = Mock(MetadataRepository))
     }
 
     def "Should throw Runtime exception when ADMIN_EMAIL metadata is not found"() {


### PR DESCRIPTION
This is a new way of testing Wicket components. There is no need to start entire Spring context which is a really heavy object. This way Wicket components test execution is a matter of seconds. Additional advantage is that we don't have to provide external Spring configuration which is specific for unit tests only, we can provide mocks at unit test level instead (see example of [`setupContext`](https://github.com/tdziurko/jvm-bloggers/compare/master...goostleek:mock-spring-context-aware-spec?expand=1#diff-1a3a4133b1c845c094f336bcfdf52e74R41)). We also don't have to provide [this dirty hack](https://github.com/tdziurko/jvm-bloggers/pull/182/files#diff-1a3a4133b1c845c094f336bcfdf52e74L35) to workaround [WICKET-605](https://issues.apache.org/jira/browse/WICKET-605). **And finally, the most anticipated feature: 
<h2>No more field injection in Spring beans used in Wicket components.</h2>**
